### PR TITLE
MTDSA-3111 - Added specific JSON validation errors

### DIFF
--- a/app/v2/controllers/requestParsers/AmendSavingsAccountAnnualSummaryRequestDataParser.scala
+++ b/app/v2/controllers/requestParsers/AmendSavingsAccountAnnualSummaryRequestDataParser.scala
@@ -31,14 +31,17 @@ class AmendSavingsAccountAnnualSummaryRequestDataParser @Inject()(validator: Ame
     validator.validate(data) match {
       case Nil =>
         //Validation passed.  Request data is ok to transform.
-        Right(AmendSavingsAccountAnnualSummaryRequest(
-          nino = Nino(data.nino),
-          desTaxYear = DesTaxYear.fromMtd(data.taxYear),
-          savingsAccountId = data.savingsAccountId,
-          data.body.json.as[SavingsAccountAnnualSummary]))
-
+        Right(
+          AmendSavingsAccountAnnualSummaryRequest(
+            nino = Nino(data.nino),
+            desTaxYear = DesTaxYear.fromMtd(data.taxYear),
+            savingsAccountId = data.savingsAccountId,
+            data.body.json.as[SavingsAccountAnnualSummary]
+          )
+        )
+      case err :: Nil if err.code.startsWith("JSON") => Left(ErrorWrapper(None, BadRequestError, Some(List(err))))
       case err :: Nil => Left(ErrorWrapper(None, err, None))
-      case errs       => Left(ErrorWrapper(None, BadRequestError, Some(errs)))
+      case errs => Left(ErrorWrapper(None, BadRequestError, Some(errs)))
     }
   }
 }

--- a/app/v2/controllers/requestParsers/CreateSavingsAccountRequestDataParser.scala
+++ b/app/v2/controllers/requestParsers/CreateSavingsAccountRequestDataParser.scala
@@ -27,9 +27,8 @@ class CreateSavingsAccountRequestDataParser @Inject()(validator: CreateSavingsAc
 
   def parseRequest(data: CreateSavingsAccountRawData): Either[ErrorWrapper, CreateSavingsAccountRequestData] = {
     validator.validate(data) match {
-      case List() =>
-        //Validation passed.  Request data is ok to transform.
-        Right(CreateSavingsAccountRequestData(Nino(data.nino), data.body.json.as[CreateSavingsAccountRequest]))
+      case Nil => Right(CreateSavingsAccountRequestData(Nino(data.nino), data.body.json.as[CreateSavingsAccountRequest]))
+      case err :: Nil if err.code.startsWith("JSON") => Left(ErrorWrapper(None, BadRequestError, Some(List(err))))
       case err :: Nil => Left(ErrorWrapper(None, err, None))
       case errs => Left(ErrorWrapper(None, BadRequestError, Some(errs)))
     }

--- a/app/v2/controllers/requestParsers/validators/AmendSavingsAccountAnnualSummaryValidator.scala
+++ b/app/v2/controllers/requestParsers/validators/AmendSavingsAccountAnnualSummaryValidator.scala
@@ -41,7 +41,7 @@ class AmendSavingsAccountAnnualSummaryValidator extends Validator[AmendSavingsAc
 
   private def bodyFormatValidator: AmendSavingsAccountAnnualSummaryRawData => List[List[Error]] = { data =>
     List(
-      JsonFormatValidation.validate[SavingsAccountAnnualSummary](data.body, RuleIncorrectOrEmptyBodyError)
+      JsonFormatValidation.validate[SavingsAccountAnnualSummary](data.body)
     )
   }
 

--- a/app/v2/controllers/requestParsers/validators/CreateSavingsAccountValidator.scala
+++ b/app/v2/controllers/requestParsers/validators/CreateSavingsAccountValidator.scala
@@ -33,7 +33,7 @@ class CreateSavingsAccountValidator extends Validator[CreateSavingsAccountRawDat
 
   private def requestRuleValidation: CreateSavingsAccountRawData => List[List[Error]] = (data: CreateSavingsAccountRawData) => {
     List(
-      JsonFormatValidation.validate[CreateSavingsAccountRequest](data.body, AccountNameMissingError)
+      JsonFormatValidation.validate[CreateSavingsAccountRequest](data.body)
     )
   }
 

--- a/app/v2/controllers/requestParsers/validators/validations/JsonFormatValidation.scala
+++ b/app/v2/controllers/requestParsers/validators/validations/JsonFormatValidation.scala
@@ -16,19 +16,53 @@
 
 package v2.controllers.requestParsers.validators.validations
 
+import play.api.Logger
 import play.api.libs.json._
 import play.api.mvc.AnyContentAsJson
-import v2.models.errors.{AccountNameMissingError, Error}
+import v2.models.errors.{BadRequestError, Error}
 
 object JsonFormatValidation {
 
-  def validate[A](data: AnyContentAsJson, error: Error)(implicit reads: Reads[A]): List[Error] = {
+  val JSON_FIELD_MISSING = "JSON_FIELD_MISSING"
+  val JSON_STRING_EXPECTED = "JSON_STRING_EXPECTED"
+  val JSON_NUMBER_EXPECTED = "JSON_NUMBER_EXPECTED"
+  val JSON_INTEGER_EXPECTED = "JSON_INTEGER_EXPECTED"
+  val JSON_BOOLEAN_EXPECTED = "JSON_BOOLEAN_EXPECTED"
+  val JSON_OBJECT_EXPECTED = "JSON_OBJECT_EXPECTED"
+  val JSON_ARRAY_EXPECTED = "JSON_ARRAY_EXPECTED"
+
+  private val logger: Logger = Logger(this.getClass)
+
+  def validate[A](data: AnyContentAsJson)(implicit reads: Reads[A]): List[Error] = {
 
     data.json.validate[A] match {
       case JsSuccess(_, _) => NoValidationErrors
-      case _               => List(error)
+      case JsError(errors) => convertJsErrors(errors)
     }
 
   }
+
+  private def convertJsErrors(errors: Seq[(JsPath, Seq[JsonValidationError])]): List[Error] = {
+    errors.toList.flatMap { data =>
+      val (path, jsonValidationErrors) = data
+      jsonValidationErrors.flatMap(error => mapSingleJsError(error, path))
+    }
+  }
+
+  private def mapSingleJsError(jsonError: JsonValidationError, path: JsPath): List[Error] = {
+    jsonError.messages.map {
+      case "error.path.missing" => Error(JSON_FIELD_MISSING, s"$path is missing")
+      case "error.expected.jsstring" => Error(JSON_STRING_EXPECTED, s"$path should be a valid JSON string")
+      case "error.expected.numberformatexception" | "error.expected.jsnumberorjsstring" => Error(JSON_NUMBER_EXPECTED, s"$path should be a valid JSON number")
+      case "error.expected.int" => Error(JSON_INTEGER_EXPECTED, s"$path should be a valid integer")
+      case "error.expected.jsboolean" => Error(JSON_BOOLEAN_EXPECTED, s"$path should be a valid JSON boolean")
+      case "error.expected.jsobject" => Error(JSON_OBJECT_EXPECTED, s"$path should be a valid JSON object")
+      case "error.expected.jsarray" => Error(JSON_ARRAY_EXPECTED, s"$path should be a valid JSON array")
+      case unmatched => {
+        logger.warn(s"[JsonFormatValidation][mapSingleJsError] - Received '$unmatched' error type and was unable to map")
+        BadRequestError
+      }
+    }
+  }.toList
 
 }

--- a/it/v2/endpoints/SavingsAccountsISpec.scala
+++ b/it/v2/endpoints/SavingsAccountsISpec.scala
@@ -21,6 +21,7 @@ import play.api.http.Status
 import play.api.libs.json.{JsValue, Json}
 import play.api.libs.ws.{WSRequest, WSResponse}
 import support.IntegrationBaseSpec
+import v2.controllers.requestParsers.validators.validations.JsonFormatValidation
 import v2.fixtures.Fixtures.SavingsAccountsFixture
 import v2.models.errors._
 import v2.stubs.{AuditStub, AuthStub, DesStub, MtdIdLookupStub}
@@ -140,11 +141,8 @@ class SavingsAccountsISpec extends IntegrationBaseSpec {
     }
 
     s"empty body is supplied" in new CreateTest {
-      val requestBody: JsValue = Json.parse(
-        s"""{
-           |
-           |}""".stripMargin
-      )
+      val requestBody: JsValue = Json.parse("{}")
+      val expectedError = Error(JsonFormatValidation.JSON_FIELD_MISSING, "/accountName is missing")
 
       override def setupStubs(): StubMapping = {
         AuditStub.audit()
@@ -154,7 +152,7 @@ class SavingsAccountsISpec extends IntegrationBaseSpec {
 
       val response: WSResponse = await(request().post(requestBody))
       response.status shouldBe Status.BAD_REQUEST
-      response.json shouldBe Json.toJson(ErrorWrapper(None, AccountNameMissingError, None))
+      response.json shouldBe Json.toJson(ErrorWrapper(None, BadRequestError, Some(List(expectedError))))
     }
   }
 

--- a/test/v2/controllers/requestParsers/validators/CreateSavingsAccountValidatorSpec.scala
+++ b/test/v2/controllers/requestParsers/validators/CreateSavingsAccountValidatorSpec.scala
@@ -19,6 +19,7 @@ package v2.controllers.requestParsers.validators
 import play.api.libs.json.Json
 import play.api.mvc.AnyContentAsJson
 import support.UnitSpec
+import v2.controllers.requestParsers.validators.validations.JsonFormatValidation
 import v2.models.errors._
 import v2.models.requestData.CreateSavingsAccountRawData
 
@@ -66,7 +67,7 @@ class CreateSavingsAccountValidatorSpec extends UnitSpec {
     "return bad request error" when {
       "empty body is supplied" in {
         val nino = "AA123456A"
-        val expectedData = List(AccountNameMissingError)
+        val expectedData = List(Error(JsonFormatValidation.JSON_FIELD_MISSING, "/accountName is missing"))
         val emptyJson =
           """
             |{

--- a/test/v2/controllers/requestParsers/validators/validations/JsonFormatValidationSpec.scala
+++ b/test/v2/controllers/requestParsers/validators/validations/JsonFormatValidationSpec.scala
@@ -19,39 +19,467 @@ package v2.controllers.requestParsers.validators.validations
 import play.api.libs.json.{Json, Reads}
 import play.api.mvc.AnyContentAsJson
 import support.UnitSpec
-import v2.models.errors.{AccountNameMissingError, Error}
+import v2.models.errors.Error
 import v2.models.utils.JsonErrorValidators
 
 class JsonFormatValidationSpec extends UnitSpec with JsonErrorValidators {
 
-  case class TestDataObject(fieldOne: String, fieldTwo: String)
+  case class Person(
+                     fullName: String,
+                     totalWorth: BigDecimal,
+                     namesOfChildren: List[String],
+                     noOfChildren: Int,
+                     employed: Boolean,
+                     favouriteBook: Book,
+                     topSecretPassword: Option[String]
+                   )
 
-  implicit val testDataObjectReads: Reads[TestDataObject] = Json.reads[TestDataObject]
+  case class Book(title: String, author: String)
 
-  val dummyError = Error("DUMMY_CODE", "dummy message")
+  implicit val bookReads: Reads[Book] = Json.reads[Book]
+  implicit val personReads: Reads[Person] = Json.reads[Person]
 
   "validate" should {
+
     "return no errors" when {
-      "when a valid JSON object with all the necessary fields is supplied" in {
 
-        val validJson = AnyContentAsJson(Json.parse("""{ "fieldOne" : "Something", "fieldTwo" : "SomethingElse" }"""))
+      "a valid JSON object with all the necessary fields is supplied" in {
 
-        val validationResult = JsonFormatValidation.validate[TestDataObject](validJson, dummyError)
-        validationResult shouldBe empty
+        val json =
+          """
+            |{
+            |    "fullName": "Timothy James Barnes",
+            |    "totalWorth": 1234567.88,
+            |    "namesOfChildren": [
+            |        "Arthur",
+            |        "Jarthur",
+            |        "Barthur",
+            |        "Narthur"
+            |    ],
+            |    "noOfChildren" : 4,
+            |    "employed": true,
+            |    "favouriteBook": {
+            |        "title": "A Thousand Splendid Suns",
+            |        "author": "Khaled Hosseini"
+            |    },
+            |    "topSecretPassword": "foobarfoobar123"
+            |}
+          """.stripMargin
+        val jsonInput = AnyContentAsJson(Json.parse(json))
+
+        val validationResult = JsonFormatValidation.validate[Person](jsonInput)
+        validationResult.isEmpty shouldBe true
+
       }
+
+      "a valid JSON object with optional fields missing is supplied" in {
+
+        val json =
+          """
+            |{
+            |    "fullName": "Timothy James Barnes",
+            |    "totalWorth": 1234567.88,
+            |    "namesOfChildren": [
+            |        "Arthur",
+            |        "Jarthur",
+            |        "Barthur",
+            |        "Narthur"
+            |    ],
+            |    "noOfChildren" : 4,
+            |    "employed": true,
+            |    "favouriteBook": {
+            |        "title": "A Thousand Splendid Suns",
+            |        "author": "Khaled Hosseini"
+            |    }
+            |}
+          """.stripMargin
+        val jsonInput = AnyContentAsJson(Json.parse(json))
+
+        val validationResult = JsonFormatValidation.validate[Person](jsonInput)
+        validationResult.isEmpty shouldBe true
+
+      }
+
+      "a valid JSON object with quoted decimal values" in {
+
+        val json =
+          """
+            |{
+            |    "fullName": "Timothy James Barnes",
+            |    "totalWorth": "1234567.88",
+            |    "namesOfChildren": [
+            |        "Arthur",
+            |        "Jarthur",
+            |        "Barthur",
+            |        "Narthur"
+            |    ],
+            |    "noOfChildren" : 4,
+            |    "employed": true,
+            |    "favouriteBook": {
+            |        "title": "A Thousand Splendid Suns",
+            |        "author": "Khaled Hosseini"
+            |    },
+            |    "topSecretPassword": "foobarfoobar123"
+            |}
+          """.stripMargin
+        val jsonInput = AnyContentAsJson(Json.parse(json))
+
+        val validationResult = JsonFormatValidation.validate[Person](jsonInput)
+        validationResult.isEmpty shouldBe true
+
+      }
+
     }
 
-    "return an error " when {
-      "when a required field is missing" in {
+    "return an error" when {
 
-        // fieldTwo is missing
-        val json = AnyContentAsJson(Json.parse("""{ "fieldOne" : "Something" }"""))
+      "a required field is missing" in {
 
-        val validationResult = JsonFormatValidation.validate[TestDataObject](json, dummyError)
-        validationResult shouldBe List(dummyError)
+        val expectedError = Error(JsonFormatValidation.JSON_FIELD_MISSING, "/totalWorth is missing")
+
+        val json =
+          """
+            |{
+            |    "fullName": "Timothy James Barnes",
+            |    "namesOfChildren": [
+            |        "Arthur",
+            |        "Jarthur",
+            |        "Barthur",
+            |        "Narthur"
+            |    ],
+            |    "noOfChildren" : 4,
+            |    "employed": true,
+            |    "favouriteBook": {
+            |        "title": "A Thousand Splendid Suns",
+            |        "author": "Khaled Hosseini"
+            |    },
+            |    "topSecretPassword": "foobarfoobar123"
+            |}
+          """.stripMargin
+        val jsonInput = AnyContentAsJson(Json.parse(json))
+
+        val validationResult = JsonFormatValidation.validate[Person](jsonInput)
+        validationResult.size shouldBe 1
+        validationResult.head shouldBe expectedError
+
+      }
+
+      "a string type is required but another type is provided" in {
+
+        val expectedError = Error(JsonFormatValidation.JSON_STRING_EXPECTED, "/fullName should be a valid JSON string")
+
+        val json =
+          """
+            |{
+            |    "fullName": 101010101110,
+            |    "totalWorth": 1234567.88,
+            |    "namesOfChildren": [
+            |        "Arthur",
+            |        "Jarthur",
+            |        "Barthur",
+            |        "Narthur"
+            |    ],
+            |    "noOfChildren" : 4,
+            |    "employed": true,
+            |    "favouriteBook": {
+            |        "title": "A Thousand Splendid Suns",
+            |        "author": "Khaled Hosseini"
+            |    },
+            |    "topSecretPassword": "foobarfoobar123"
+            |}
+          """.stripMargin
+        val jsonInput = AnyContentAsJson(Json.parse(json))
+
+        val validationResult = JsonFormatValidation.validate[Person](jsonInput)
+        validationResult.size shouldBe 1
+        validationResult.head shouldBe expectedError
+
+      }
+
+      "a number type is required but another type is provided" in {
+
+        val expectedError = Error(JsonFormatValidation.JSON_NUMBER_EXPECTED, "/totalWorth should be a valid JSON number")
+
+        val json =
+          """
+            |{
+            |    "fullName": "Timothy James Barnes",
+            |    "totalWorth": "Timothy James Barnes",
+            |    "namesOfChildren": [
+            |        "Arthur",
+            |        "Jarthur",
+            |        "Barthur",
+            |        "Narthur"
+            |    ],
+            |    "noOfChildren" : 4,
+            |    "employed": true,
+            |    "favouriteBook": {
+            |        "title": "A Thousand Splendid Suns",
+            |        "author": "Khaled Hosseini"
+            |    },
+            |    "topSecretPassword": "foobarfoobar123"
+            |}
+          """.stripMargin
+        val jsonInput = AnyContentAsJson(Json.parse(json))
+
+        val validationResult = JsonFormatValidation.validate[Person](jsonInput)
+        validationResult.size shouldBe 1
+        validationResult.head shouldBe expectedError
+
+      }
+
+      "a boolean type is required but another type is provided" in {
+
+        val expectedError = Error(JsonFormatValidation.JSON_BOOLEAN_EXPECTED, "/employed should be a valid JSON boolean")
+
+        val json =
+          """
+            |{
+            |    "fullName": "Timothy James Barnes",
+            |    "totalWorth": 1234567.88,
+            |    "namesOfChildren": [
+            |        "Arthur",
+            |        "Jarthur",
+            |        "Barthur",
+            |        "Narthur"
+            |    ],
+            |    "noOfChildren" : 4,
+            |    "employed": "Yes Sir",
+            |    "favouriteBook": {
+            |        "title": "A Thousand Splendid Suns",
+            |        "author": "Khaled Hosseini"
+            |    },
+            |    "topSecretPassword": "foobarfoobar123"
+            |}
+          """.stripMargin
+        val jsonInput = AnyContentAsJson(Json.parse(json))
+
+        val validationResult = JsonFormatValidation.validate[Person](jsonInput)
+        validationResult.size shouldBe 1
+        validationResult.head shouldBe expectedError
+
+      }
+
+      "an integer type is required but another type is provided" in {
+
+        val expectedError = Error(JsonFormatValidation.JSON_INTEGER_EXPECTED, "/noOfChildren should be a valid integer")
+
+        val json =
+          """
+            |{
+            |    "fullName": "Timothy James Barnes",
+            |    "totalWorth": 1234567.88,
+            |    "namesOfChildren": [
+            |        "Arthur",
+            |        "Jarthur",
+            |        "Barthur",
+            |        "Narthur"
+            |    ],
+            |    "noOfChildren" : 7.7,
+            |    "employed": true,
+            |    "favouriteBook": {
+            |        "title": "A Thousand Splendid Suns",
+            |        "author": "Khaled Hosseini"
+            |    },
+            |    "topSecretPassword": "foobarfoobar123"
+            |}
+          """.stripMargin
+        val jsonInput = AnyContentAsJson(Json.parse(json))
+
+        val validationResult = JsonFormatValidation.validate[Person](jsonInput)
+        validationResult.size shouldBe 1
+        validationResult.head shouldBe expectedError
+
+      }
+
+      "an object is required but another type is provided" in {
+
+        val expectedError = Error(JsonFormatValidation.JSON_OBJECT_EXPECTED, "/favouriteBook should be a valid JSON object")
+
+        val json =
+          """
+            |{
+            |    "fullName": "Timothy James Barnes",
+            |    "totalWorth": 1234567.88,
+            |    "namesOfChildren": [
+            |        "Arthur",
+            |        "Jarthur",
+            |        "Barthur",
+            |        "Narthur"
+            |    ],
+            |    "noOfChildren" : 4,
+            |    "employed": true,
+            |    "favouriteBook": "Kite Runner",
+            |    "topSecretPassword": "foobarfoobar123"
+            |}
+          """.stripMargin
+        val jsonInput = AnyContentAsJson(Json.parse(json))
+
+        val validationResult = JsonFormatValidation.validate[Person](jsonInput)
+        validationResult.size shouldBe 1
+        validationResult.head shouldBe expectedError
+
+      }
+
+      "a decimal value is required but another type is provided" in {
+
+        val expectedError = Error(JsonFormatValidation.JSON_NUMBER_EXPECTED, "/totalWorth should be a valid JSON number")
+
+        val json =
+          """
+            |{
+            |    "fullName": "Timothy James Barnes",
+            |    "totalWorth": { "net": 2500 },
+            |    "namesOfChildren": [
+            |        "Arthur",
+            |        "Jarthur",
+            |        "Barthur",
+            |        "Narthur"
+            |    ],
+            |    "noOfChildren" : 4,
+            |    "employed": true,
+            |    "favouriteBook": {
+            |        "title": "A Thousand Splendid Suns",
+            |        "author": "Khaled Hosseini"
+            |    },
+            |    "topSecretPassword": "foobarfoobar123"
+            |}
+          """.stripMargin
+        val jsonInput = AnyContentAsJson(Json.parse(json))
+
+        val validationResult = JsonFormatValidation.validate[Person](jsonInput)
+        validationResult.size shouldBe 1
+        validationResult.head shouldBe expectedError
+
+      }
+
+      "an array is required but another type is provided" in {
+        val expectedError = Error(JsonFormatValidation.JSON_ARRAY_EXPECTED, "/namesOfChildren should be a valid JSON array")
+
+        val json =
+          """
+            |{
+            |    "fullName": "Timothy James Barnes",
+            |    "totalWorth": 1234567.88,
+            |    "namesOfChildren": "Timmy and Tommy",
+            |    "noOfChildren" : 2,
+            |    "employed": true,
+            |    "favouriteBook": {
+            |        "title": "A Thousand Splendid Suns",
+            |        "author": "Khaled Hosseini"
+            |    },
+            |    "topSecretPassword": "foobarfoobar123"
+            |}
+          """.stripMargin
+        val jsonInput = AnyContentAsJson(Json.parse(json))
+
+        val validationResult = JsonFormatValidation.validate[Person](jsonInput)
+        validationResult.size shouldBe 1
+        validationResult.head shouldBe expectedError
+
+      }
+
+      "an error occurs below the first level of the json data" in {
+        val expectedError = Error(JsonFormatValidation.JSON_FIELD_MISSING, "/favouriteBook/title is missing")
+
+        val json =
+          """
+            |{
+            |    "fullName": "Timothy James Barnes",
+            |    "totalWorth": 1234567.88,
+            |    "namesOfChildren": [
+            |        "Arthur",
+            |        "Jarthur",
+            |        "Barthur",
+            |        "Narthur"
+            |    ],
+            |    "noOfChildren" : 4,
+            |    "employed": true,
+            |    "favouriteBook": {
+            |        "author": "Khaled Hosseini"
+            |    },
+            |    "topSecretPassword": "foobarfoobar123"
+            |}
+          """.stripMargin
+        val jsonInput = AnyContentAsJson(Json.parse(json))
+
+        val validationResult = JsonFormatValidation.validate[Person](jsonInput)
+        validationResult.size shouldBe 1
+        validationResult.head shouldBe expectedError
+      }
+
+    }
+
+    "return multiple errors" when {
+
+      "invalid types are provided in an array" in {
+
+        val expectedErrorOne = Error(JsonFormatValidation.JSON_STRING_EXPECTED, "/namesOfChildren(0) should be a valid JSON string")
+        val expectedErrorTwo = Error(JsonFormatValidation.JSON_STRING_EXPECTED, "/namesOfChildren(1) should be a valid JSON string")
+        val expectedErrorThree = Error(JsonFormatValidation.JSON_STRING_EXPECTED, "/namesOfChildren(2) should be a valid JSON string")
+
+        val json =
+          """
+            |{
+            |    "fullName": "Timothy James Barnes",
+            |    "totalWorth": 1234567.88,
+            |    "namesOfChildren": [ 1, 2, 3 ],
+            |    "noOfChildren" : 3,
+            |    "employed": true,
+            |    "favouriteBook": {
+            |        "title": "A Thousand Splendid Suns",
+            |        "author": "Khaled Hosseini"
+            |    },
+            |    "topSecretPassword": "foobarfoobar123"
+            |}
+          """.stripMargin
+        val jsonInput = AnyContentAsJson(Json.parse(json))
+
+        val validationResult = JsonFormatValidation.validate[Person](jsonInput)
+        validationResult.size shouldBe 3
+        validationResult.contains(expectedErrorOne) shouldBe true
+        validationResult.contains(expectedErrorTwo) shouldBe true
+        validationResult.contains(expectedErrorThree) shouldBe true
+
+      }
+
+      "multiple incorrect types are provided" in {
+
+        val expectedErrorOne = Error(JsonFormatValidation.JSON_STRING_EXPECTED, "/fullName should be a valid JSON string")
+        val expectedErrorTwo = Error(JsonFormatValidation.JSON_NUMBER_EXPECTED, "/totalWorth should be a valid JSON number")
+
+        val json =
+          """
+            |{
+            |    "fullName": 1234567.88,
+            |    "totalWorth": "Timothy James Barnes",
+            |    "namesOfChildren": [
+            |        "Arthur",
+            |        "Jarthur",
+            |        "Barthur",
+            |        "Narthur"
+            |    ],
+            |    "noOfChildren" : 4,
+            |    "employed": true,
+            |    "favouriteBook": {
+            |        "title": "A Thousand Splendid Suns",
+            |        "author": "Khaled Hosseini"
+            |    },
+            |    "topSecretPassword": "foobarfoobar123"
+            |}
+          """.stripMargin
+        val jsonInput = AnyContentAsJson(Json.parse(json))
+
+        val validationResult = JsonFormatValidation.validate[Person](jsonInput)
+
+        validationResult.size shouldBe 2
+        validationResult.contains(expectedErrorOne) shouldBe true
+        validationResult.contains(expectedErrorTwo) shouldBe true
+
       }
 
     }
 
   }
+
 }


### PR DESCRIPTION
Needs discussion before merging. 

* By implementing this validation we essentially make the following two errors redundant:
    * `RULE_INCORRECT_OR_EMPTY_BODY_SUBMITTED`
    * `MISSING_ACCOUNT_NAME`

It is in the RAML documentation but will no longer be returned for this microservice.